### PR TITLE
Switch to Alpine-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:slim
+FROM alpine:3.4
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g bower gulp node-sass
+# musl-dev is required for the node-sass binary from https://github.com/sass/node-sass/issues/1589
+RUN apk add --no-cache ca-certificates git musl-dev nodejs \
+    && apk add --no-cache --virtual build-deps gcc g++ make python \
+    && npm install -g bower gulp node-sass \
+    && apk del build-deps
 
 COPY ./docker-entrypoint.sh /
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 driebit/node-gulp
 =================
 
-Run a [Gulp](http://gulpjs.com/) task in a Docker container.
+Run a [Gulp](http://gulpjs.com/) task in an Alpine-based Docker container.
 
 Usage
 -----

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -f ./bower.json ]; then
     bower install --allow-root


### PR DESCRIPTION
Fix #1. Reduced size to 83 MB.

Thanks to https://github.com/sass/node-sass/issues/1589 an Alpine-compatible node-sass binary is available from 4.1.0 onwards.

Requires gulp-sass ^3.0.0 with node-sass ^4.1.0.
